### PR TITLE
Added modifyParam.R and associated test file

### DIFF
--- a/R/modifyParam.R
+++ b/R/modifyParam.R
@@ -16,7 +16,7 @@
 #     cs = modifyParam(ps, id="power", lower = 333, upper = 333)
 #     cs = modifyParam(ps, id="gas", lower = list("Argon", "Nitrogen"))
 #  if modifying an existing constraint set
-#    cs = modifyParam(ps, cs, id="gas", lower = "Argon", upper="Nitrogen")
+#     cs = modifyParam(ps, cs, id="gas", lower = "Argon", upper="Nitrogen")
 
 modifyParam = function(ps, cs = NULL, id = NULL, lower = NULL, upper = NULL) {
     psParamIDs = getParamIds(ps)
@@ -40,11 +40,7 @@ modifyParam = function(ps, cs = NULL, id = NULL, lower = NULL, upper = NULL) {
                 cs[["pars"]][[id]][["upper"]] = validNum(ps, id, upper, "upper")
             # for parameters of type discrete
             } else if (cs[["pars"]][[id]][["type"]] == "discrete") {
-                values = c()
-                # make list of valid discrete values for parameter id
-                for (value in ps[["pars"]][[id]][["values"]]) {
-                    values = append(values, value)
-                }
+                values = ps[["pars"]][[id]][["values"]]
                 appVal = 0L
                 # if lower is not NULL and in ps's set of param IDs then copy value to cs
                 if (!(is.null(lower))) {
@@ -52,7 +48,8 @@ modifyParam = function(ps, cs = NULL, id = NULL, lower = NULL, upper = NULL) {
                         if (lower %in% values) {
                             appVal = 2L
                         } else {
-                            cat("Warning:",lower,"not a valid value for",id,"\b, using values from parameter set\n")
+                            warning(lower, " not a valid value for ", id, 
+                            ", using values from parameter set\n")
                             appVal = 1L
                         }
                     } else if (class(lower) == "list") {
@@ -62,7 +59,7 @@ modifyParam = function(ps, cs = NULL, id = NULL, lower = NULL, upper = NULL) {
                                 apndLow = append(apndLow, low)
                                 appVal = 2L
                             } else {
-                                cat("Warning:",low,"not a valid value for",id,"\n")
+                                warning(low, " not a valid value for ", id, "\n")
                             }
                         }
                     }
@@ -74,7 +71,8 @@ modifyParam = function(ps, cs = NULL, id = NULL, lower = NULL, upper = NULL) {
                             if (appVal == 0L) appVal = 3L
                             if (appVal == 2L) appVal = 4L
                         } else {
-                            cat("Warning:",upper,"not a valid value for",id,"\b, using values from parameter set\n")
+                            warning(upper, " not a valid value for ", id, 
+                            ", using values from parameter set\n")
                             appVal = 1L
                         }
                     } else if (class(upper) == "list") {
@@ -85,7 +83,7 @@ modifyParam = function(ps, cs = NULL, id = NULL, lower = NULL, upper = NULL) {
                                 if (appVal == 0L) appVal = 3L
                                 if (appVal == 2L) appVal = 4L
                             } else {
-                                cat("Warning:",up,"not a valid value for",id,"\n")
+                                warning(up, " not a valid value for ", id, "\n")
                             }   
                         }
                     }
@@ -114,10 +112,10 @@ modifyParam = function(ps, cs = NULL, id = NULL, lower = NULL, upper = NULL) {
                 } 
             # other types of parameters not supported
             } else {
-                print("modifyParam only implemented for types of integer, numeric & discrete")
+                stopf("modifyParam only implemented for types of integer, numeric & discrete")
             }
         } else {
-            cat("Warning:",id,"not in parameter set, ignoring constraint\n")
+            warning(id, " not in parameter set, ignoring constraint\n")
         }
     }
 
@@ -133,10 +131,10 @@ validNum = function(ps, id, limitVal, limit) {
                 limitVal <= ps[["pars"]][[id]][["upper"]]) {
                 ret = limitVal
             } else {
-                cat("Warning:",limitVal,"is outside parameter limits, using limit from parameter set\n")
+                warning(limitVal, " is outside parameter limits, using limit from parameter set\n")
             }
         } else {
-            cat("Warning: integer and numeric parameters must have class(value) = numeric\n")
+            warning("integer and numeric parameters must have class(value) = numeric\n")
 
         }
     }

--- a/R/modifyParam.R
+++ b/R/modifyParam.R
@@ -1,0 +1,146 @@
+#' @title modifyParam.R
+#' @description copy parameter set to new set, cs, and modify lower
+#'              and upper limits of one parameter id.  If parameter is
+#'              discrete then change list of permitted values.
+#'
+#' @param ps - a parameter set, class(ps) = "ParamSet"
+#' @param cs - a constraint set, class(ps) = "ParamSet"
+#' @param id - id/name of parameter to alter in new set, character
+#' @param lower - new lower limit for id - integer, numeric, character or list of character
+#' @param upper - new upper limit for id - integer, numeric, character or list of character
+#'
+#' @return cs - the new constraint set with class(cs) = "ParamSet"
+#
+#
+# usage example:
+#     cs = modifyParam(ps, id="power", lower = 333, upper = 333)
+#     cs = modifyParam(ps, id="gas", lower = list("Argon", "Nitrogen"))
+#  if modifying an existing constraint set
+#    cs = modifyParam(ps, cs, id="gas", lower = "Argon", upper="Nitrogen")
+
+modifyParam = function(ps, cs = NULL, id = NULL, lower = NULL, upper = NULL) {
+    psParamIDs = getParamIds(ps)
+    if (is.null(cs) || !(class(cs) == "ParamSet")) {
+        cs = ps
+    }
+    csParamIDs = getParamIds(cs)
+    
+    if (!(is.null(id))) {
+        if (id %in% psParamIDs) {
+            # if param id is in parameter set but not constraint set copy to cs
+            if (!(id %in% csParamIDs)) {
+                cs[["pars"]][[id]] = ps[["pars"]][[id]]
+            }
+            # for parameters of type integer or numeric
+            if (cs[["pars"]][[id]][["type"]] == "integer" || 
+                cs[["pars"]][[id]][["type"]] == "numeric") {
+                # if lower is not NULL and within valid limits then set to new lower
+                cs[["pars"]][[id]][["lower"]] = validNum(ps, id, lower, "lower")
+                # if upper is not NULL and within valid limits then set to new upper
+                cs[["pars"]][[id]][["upper"]] = validNum(ps, id, upper, "upper")
+            # for parameters of type discrete
+            } else if (cs[["pars"]][[id]][["type"]] == "discrete") {
+                values = c()
+                # make list of valid discrete values for parameter id
+                for (value in ps[["pars"]][[id]][["values"]]) {
+                    values = append(values, value)
+                }
+                appVal = 0L
+                # if lower is not NULL and in ps's set of param IDs then copy value to cs
+                if (!(is.null(lower))) {
+                    if (class(lower) == "character" && length(lower) == 1) {
+                        if (lower %in% values) {
+                            appVal = 2L
+                        } else {
+                            cat("Warning:",lower,"not a valid value for",id,"\b, using values from parameter set\n")
+                            appVal = 1L
+                        }
+                    } else if (class(lower) == "list") {
+                        apndLow = list()
+                        for (low in lower) {
+                            if (low %in% values) {
+                                apndLow = append(apndLow, low)
+                                appVal = 2L
+                            } else {
+                                cat("Warning:",low,"not a valid value for",id,"\n")
+                            }
+                        }
+                    }
+                }
+                # if upper is not NULL and in ps's set of param IDs then copy value to cs
+                if (!(is.null(upper))) {
+                    if (class(upper) == "character" && length(upper) == 1L) {
+                        if (upper %in% values) {
+                            if (appVal == 0L) appVal = 3L
+                            if (appVal == 2L) appVal = 4L
+                        } else {
+                            cat("Warning:",upper,"not a valid value for",id,"\b, using values from parameter set\n")
+                            appVal = 1L
+                        }
+                    } else if (class(upper) == "list") {
+                        apndUp = list()
+                        for (up in upper) {
+                            if (up %in% values) {
+                                apndUp = append(apndUp, up)
+                                if (appVal == 0L) appVal = 3L
+                                if (appVal == 2L) appVal = 4L
+                            } else {
+                                cat("Warning:",up,"not a valid value for",id,"\n")
+                            }   
+                        }
+                    }
+                }
+                # determine how to append values to a discrete parameter
+                if (appVal >= 2L) {
+                    cs[["pars"]][[id]][["values"]] = NULL
+                    if (appVal == 2L) {
+                        if (class(lower) == "character") apnd = list(lower)
+                        if (class(lower) == "list") apnd = apndLow
+                    } else if (appVal == 3L) {
+                        if (class(upper) == "character") apnd = list(upper)
+                        if (class(upper) == "list") apnd = apndUp
+                    } else if (appVal == 4L) {
+                        if (class(lower) == "list") {
+                            apnd = append(lower, upper)
+                        } else if (class(lower) == "character" && class(upper) == "list") {
+                            apnd = append(upper, lower)
+                        } else {
+                            apnd = list(lower, upper)
+                        }
+                    }
+                    apnd = unique(apnd)
+                    cs[["pars"]][[id]][["values"]] = apnd
+                    names(cs[["pars"]][[id]][["values"]]) = apnd
+                } 
+            # other types of parameters not supported
+            } else {
+                print("modifyParam only implemented for types of integer, numeric & discrete")
+            }
+        } else {
+            cat("Warning:",id,"not in parameter set, ignoring constraint\n")
+        }
+    }
+
+    return(cs)
+}
+
+# if limitVal is within limts and "numeric" return limitVal, otherwise return ps limit
+validNum = function(ps, id, limitVal, limit) {
+    ret = ps[["pars"]][[id]][[limit]]
+    if (!(is.null(limitVal))) {
+        if (class(limitVal) == "numeric") {
+            if (limitVal >= ps[["pars"]][[id]][["lower"]] && 
+                limitVal <= ps[["pars"]][[id]][["upper"]]) {
+                ret = limitVal
+            } else {
+                cat("Warning:",limitVal,"is outside parameter limits, using limit from parameter set\n")
+            }
+        } else {
+            cat("Warning: integer and numeric parameters must have class(value) = numeric\n")
+
+        }
+    }
+    return(ret)
+}
+
+

--- a/tests/testthat/test_modifyParam.R
+++ b/tests/testthat/test_modifyParam.R
@@ -1,0 +1,109 @@
+library(testthat)
+context("modifyParam")
+
+test_that("modifyParam properly modifies parameter limits/values", {
+   
+    ps = makeParamSet(
+    makeIntegerParam("power", lower = 10, upper = 5555),
+    makeIntegerParam("time", lower = 500, upper = 20210),
+    makeDiscreteParam("gas", values = c("Nitrogen", "Air", "Argon")),
+    makeIntegerParam("pressure", lower = 20, upper = 1000)
+    )
+    
+    # Normal operation - correct limits, values and ids
+    
+    # set parameter to one value 
+    ms = modifyParam(ps, id="power", lower = 444, upper = 444)
+    expect_equal(ms[["pars"]][["power"]][["lower"]], 444)
+    expect_equal(ms[["pars"]][["power"]][["upper"]], 444)
+    
+    # set parameter to range of values
+    ms = modifyParam(ps, id="power", lower = 444, upper = 555)
+    expect_equal(ms[["pars"]][["power"]][["lower"]], 444)
+    expect_equal(ms[["pars"]][["power"]][["upper"]], 555)
+    
+    # A number of ways to set values for a discrete parameter
+    ms = modifyParam(ps, id="gas", lower = "Argon")
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Argon"]], "Argon")
+    expect_null(ms[["pars"]][["gas"]][["values"]][["Nitrogen"]])
+    expect_null(ms[["pars"]][["gas"]][["values"]][["Air"]])
+    
+    ms = modifyParam(ps, id="gas", lower = list("Argon", "Nitrogen"))
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Argon"]], "Argon")
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Nitrogen"]], "Nitrogen")
+    expect_null(ms[["pars"]][["gas"]][["values"]][["Air"]])
+    
+    ms = modifyParam(ps, id="gas", upper = list("Air", "Argon"))
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Argon"]], "Argon")
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Air"]], "Air")
+    expect_null(ms[["pars"]][["gas"]][["values"]][["Nitrogen"]])
+    
+    ms = modifyParam(ps, id="gas", lower = "Air", upper = "Nitrogen")
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Nitrogen"]], "Nitrogen")
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Air"]], "Air")
+    expect_null(ms[["pars"]][["gas"]][["values"]][["Argon"]])
+    
+    # Incorrect/Invalid/Outside-limit  values/limits/ids
+    
+    # if no upper/lower value given, defaults to original value from ps
+    ms = modifyParam(ps, id="power", lower = 444)
+    expect_equal(ms[["pars"]][["power"]][["lower"]], 444)
+    expect_equal(ms[["pars"]][["power"]][["upper"]], 5555)
+    ms = modifyParam(ps, id="power", upper = 444)
+    expect_equal(ms[["pars"]][["power"]][["lower"]], 10)
+    expect_equal(ms[["pars"]][["power"]][["upper"]], 444)
+    
+    # if upper/lower outside limits of ps, set to ps limits
+    ms = modifyParam(ps, id="pressure", lower = -3, upper = 444)
+    expect_equal(ms[["pars"]][["pressure"]][["lower"]], 20)
+    expect_equal(ms[["pars"]][["pressure"]][["upper"]], 444)
+    ms = modifyParam(ps, id="pressure", lower = 333, upper = 22000)
+    expect_equal(ms[["pars"]][["pressure"]][["lower"]], 333)
+    expect_equal(ms[["pars"]][["pressure"]][["upper"]], 1000)
+    ms = modifyParam(ps, id="pressure", lower = 12, upper = 3)
+    expect_equal(ms[["pars"]][["pressure"]][["lower"]], 20)
+    expect_equal(ms[["pars"]][["pressure"]][["upper"]], 1000)
+    
+    # if non-existant value given for discrete param use value set from ps
+    ms = modifyParam(ps, id="gas", lower = "Airrr")
+    expect_equal(ms[["pars"]][["gas"]][["values"]], ps[["pars"]][["gas"]][["values"]])
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Nitrogen"]], "Nitrogen")
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Air"]], "Air")
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Argon"]], "Argon")
+    expect_null(ms[["pars"]][["gas"]][["values"]][["Airrr"]])
+    
+    # if no value given for discrete param use those from ps
+    ms = modifyParam(ps, id="gas")
+    expect_equal(ms[["pars"]][["gas"]][["values"]], ps[["pars"]][["gas"]][["values"]])
+    
+    # if non-existant value given for discrete param use value set from ps
+    ms = modifyParam(ps, id="gas", lower = "Nitrogen", upper = "Arrgon")
+    expect_equal(ms[["pars"]][["gas"]][["values"]], ps[["pars"]][["gas"]][["values"]])
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Nitrogen"]], "Nitrogen")
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Air"]], "Air")
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Argon"]], "Argon")
+    expect_null(ms[["pars"]][["gas"]][["values"]][["Arrgon"]])
+    
+    # if non-existant value given for discrete param in a list ignore that value
+    ms = modifyParam(ps, id="gas", lower = list("Air","Arrgon"))
+    expect_equal(ms[["pars"]][["gas"]][["values"]][["Air"]], "Air")
+    expect_null(ms[["pars"]][["gas"]][["values"]][["Nitrogen"]])
+    expect_null(ms[["pars"]][["gas"]][["values"]][["Argon"]])
+    expect_null(ms[["pars"]][["gas"]][["values"]][["Arrgon"]])
+    
+    # if param id does not exist in ps, returns ps
+    ms = modifyParam(ps, id="powwer", lower = 444, upper = 54321)
+    expect_equal(ps, ms)
+    ms = modifyParam(ps, id="ggas", lower = list("Argon", "Nitrogen"))
+    expect_equal(ps, ms)
+    
+    # if parameter value is of wrong type, sets to ps values
+    ms = modifyParam(ps, id="power", lower = "abc", upper = 5555)
+    expect_equal(ps, ms)
+    ms = modifyParam(ps, id="gas", lower = 444)
+    expect_equal(ps, ms)
+    
+    
+
+
+})


### PR DESCRIPTION
Added modifyParam.R and test_modifyParam.R
modifyParam allows a user to change the value/range of a parameter in a parameter set.  
Usage example:
    ms = modifyParam(ps, id="power", lower = 444, upper = 444)
where ms is the new parameter set, ps is the paramSet to change, id is parameter to change and lower and upper are the new values.  Can be one value as the above example or a range of values.  
Also works for discrete parameters as in:
    ms = modifyParam(ps, id="gas", lower = list("Argon", "Nitrogen"))

modifyParam validates the new values versus those in the original paramSet, and returns a new cleaned up parameter set.

Was intended to be used with some slight changes to mlrMBO to constrain a parameter in a focus search for an optimal value of another parameter.