### PR TITLE
handle long requires in generateDesign()

### DIFF
--- a/R/generateDesign.R
+++ b/R/generateDesign.R
@@ -231,7 +231,7 @@ determineReqVectorized = function(pars) {
   # heuristic if we allow this requirement to be evaluated in an vectorized fashion
   vapply(X = lapply(pars, function(p) p$requires), function(req) {
     # vectorized if no "&&", "||" or "(" is detected
-    !grepl(x = deparse(req), pattern = "\\|\\||&&|\\(")
+    !any(grepl(x = deparse(req), pattern = "\\|\\||&&|\\("))
   }, FUN.VALUE = logical(1))
 }
 


### PR DESCRIPTION
`deparse()` can create vectors with more than one element when the expression being deparsed is long; vapply() will then throw an error because the return of `grepl()` is not a scalar any more in that case.